### PR TITLE
[feature] update to 'minidom:0.13.0'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minidom_ext"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "MIT"
 description = "Extension traits for minidom::Element"
@@ -10,7 +10,7 @@ keywords = ["minidom", "extension"]
 
 [dependencies]
 anyhow = "1"
-minidom = "0.12"
+minidom = "0.13"
 thiserror = "1"
 
 [dev-dependencies]

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -39,7 +39,7 @@ impl AttributeElementExt for Element {
     /// use minidom::Element;
     /// use minidom_ext::AttributeElementExt;
     ///
-    /// let xml: &'static str = r#"<root id="42" />"#;
+    /// let xml: &'static str = r#"<root xmlns="ns" id="42" />"#;
     /// let root: Element = xml.parse().unwrap();
     /// let id: u64 = root.try_attribute("id").unwrap();
     /// assert_eq!(42, id);
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn no_attribute() {
-        let xml: &'static str = r#"<root />"#;
+        let xml: &'static str = r#"<root xmlns="ns" />"#;
         let root: Element = xml.parse().unwrap();
         let error = root.try_attribute::<String>("id").unwrap_err();
         assert_eq!(
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn no_children() {
-        let xml: &'static str = r#"<root id="root:1" />"#;
+        let xml: &'static str = r#"<root xmlns="ns" id="root:1" />"#;
         let root: Element = xml.parse().unwrap();
         let error = root.try_attribute::<f64>("id").unwrap_err();
         assert_eq!("Failed to parse and convert the value \'root:1\' of attribute \'id\' in element \'root\'", format!("{}", error));

--- a/src/only_child.rs
+++ b/src/only_child.rs
@@ -70,7 +70,7 @@ impl OnlyChildElementExt for Element {
     /// use minidom::Element;
     /// use minidom_ext::OnlyChildElementExt;
     ///
-    /// let xml: &'static str = r#"<root>
+    /// let xml: &'static str = r#"<root xmlns="ns">
     ///         <child type="ugly" />
     ///         <child />
     ///     </root>"#;
@@ -112,7 +112,7 @@ impl OnlyChildElementExt for Element {
     /// use minidom::Element;
     /// use minidom_ext::OnlyChildElementExt;
     ///
-    /// let xml: &'static str = r#"<root>
+    /// let xml: &'static str = r#"<root xmlns="ns">
     ///         <child />
     ///     </root>"#;
     /// let root: Element = xml.parse().unwrap();
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn only_one_child() {
-        let xml: &'static str = r#"<root>
+        let xml: &'static str = r#"<root xmlns="ns">
                 <child type="ugly" />
                 <child />
             </root>"#;
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn no_children() {
-        let xml: &'static str = r#"<root />"#;
+        let xml: &'static str = r#"<root xmlns="ns" />"#;
         let root: Element = xml.parse().unwrap();
         let error = root
             .try_find_only_child(|e| e.name() == "child")
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn multiple_child() {
-        let xml: &'static str = r#"<root>
+        let xml: &'static str = r#"<root xmlns="ns">
                 <child />
                 <child />
             </root>"#;


### PR DESCRIPTION
Updating to `minidom:0.13.0` and also removing the dependency to `quick_xml` from `Cargo.toml`. `quick_xml` is actually exposed through `minidom` and doing this way avoids non-matching versions between `minidom` and `quick_xml`.