### PR TITLE
update outdated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minidom_ext"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "MIT"
 description = "Extension traits for minidom::Element"
@@ -14,4 +14,4 @@ minidom = "0.12"
 thiserror = "1"
 
 [dev-dependencies]
-pretty_assertions = "0.6"
+pretty_assertions = "1"


### PR DESCRIPTION
This takes parts of a larger effort to unify all dependencies in mimirsbrunn and will allow to do the same work for https://github.com/CanalTP/transit_model/.

There is a rather small change here as we should not update do minidom>12: https://github.com/CanalTP/transit_model/pull/746